### PR TITLE
Generate integer constants as signed

### DIFF
--- a/nutcracker/Expressions.h
+++ b/nutcracker/Expressions.h
@@ -207,7 +207,7 @@ public:
 	void set( unsigned int value )
 	{
 		m_isLiteral = false;
-		m_text.setNum(value);
+		m_text.setNum(int(value));
 	}
 
 


### PR DESCRIPTION
Change squirrel integer constant expression text representation to singed integer string instead of unsigned for code generation.